### PR TITLE
Query with Eq Fails

### DIFF
--- a/lib/dynamodb_framework/dynamodb_query.rb
+++ b/lib/dynamodb_framework/dynamodb_query.rb
@@ -21,12 +21,12 @@ module DynamoDbFramework
     end
 
     def eq(value)
-      condition(expression: '==', value: value)
+      condition(expression: '=', value: value)
       self
     end
 
     def not_eq(value)
-      condition(expression: '!=', value: value)
+      condition(expression: '<>', value: value)
       self
     end
 

--- a/lib/dynamodb_framework/version.rb
+++ b/lib/dynamodb_framework/version.rb
@@ -1,3 +1,3 @@
 module DynamoDbFramework
-  VERSION = '1.5.1'
+  VERSION = '1.5.2'
 end

--- a/spec/dynamodb_query_spec.rb
+++ b/spec/dynamodb_query_spec.rb
@@ -88,6 +88,18 @@ RSpec.describe DynamoDbFramework::Query do
         expect(count).to eq 4
       end
     end
+    context 'when using eq' do
+      it 'should return the right values' do
+        results = ExampleTable2.query(partition: 'name 1').number.eq(1).execute(store: store)
+        expect(results.length).to eq(1)
+      end
+    end
+    context 'when using not_eq' do
+      it 'should return the right values' do
+        results = ExampleTable2.query(partition: 'name 1').number.not_eq(1).execute(store: store)
+        expect(results.length).to eq(3)
+      end
+    end
   end
 
 end

--- a/spec/dynamodb_table_spec.rb
+++ b/spec/dynamodb_table_spec.rb
@@ -152,6 +152,14 @@ RSpec.describe DynamoDbFramework::Table do
                     .execute(store: store)
       expect(results.length).to eq 4
     end
+
+    context 'when using eq' do
+      it 'should returnt the right values' do
+        results = ExampleTable2.query(partition: 'name 1').number.eq(1).execute(store: store)
+        expect(results.length).to eq(1)
+      end
+    end
+
     context 'when limit is specified' do
       it 'should return the expected items' do
         results = ExampleTable2.query(partition: 'name 1')

--- a/spec/dynamodb_table_spec.rb
+++ b/spec/dynamodb_table_spec.rb
@@ -153,13 +153,6 @@ RSpec.describe DynamoDbFramework::Table do
       expect(results.length).to eq 4
     end
 
-    context 'when using eq' do
-      it 'should returnt the right values' do
-        results = ExampleTable2.query(partition: 'name 1').number.eq(1).execute(store: store)
-        expect(results.length).to eq(1)
-      end
-    end
-
     context 'when limit is specified' do
       it 'should return the expected items' do
         results = ExampleTable2.query(partition: 'name 1')


### PR DESCRIPTION
There seems to be a problem with a query that uses the `eq` command.
`Invalid FilterExpression: Syntax error; token: "=", near: "== :p0"`


 ```
       ExampleTable2.query(partition: 'name 1').number.eq(1).execute(store: store)
        Aws::DynamoDB::Errors::ValidationException: Invalid FilterExpression: Syntax error; token: "=", near: "== :p0"
        from /usr/lib/ruby/gems/2.3.0/gems/aws-sdk-core-2.10.21/lib/seahorse/client/plugins/raise_response_errors.rb:15:in `call'
        [23] pry(#<RSpec::ExampleGroups::DynamoDbFrameworkTable::Query>)>
```