### PR TITLE
Handle table creation race condition

### DIFF
--- a/lib/dynamodb_framework/dynamodb_table_manager.rb
+++ b/lib/dynamodb_framework/dynamodb_table_manager.rb
@@ -326,7 +326,11 @@ module DynamoDbFramework
         table[:global_secondary_indexes] = options[:global_indexes]
       end
 
-      dynamodb.client.create_table(table)
+      begin
+        dynamodb.client.create_table(table)
+      rescue Aws::DynamoDB::Errors::ResourceInUseException => e
+        DynamoDbFramework.logger.warn "[#{self.class}] - Table #{table_name} already exists!"
+      end
 
       # wait for table to be created
       DynamoDbFramework.logger.info "[#{self.class}] - Waiting for table: [#{table_name}] to be created."


### PR DESCRIPTION
The framework has an existing check for table existence but it's non-atomic and subject to a race condition when multiple apps call it at the same time.

This PR fixes the problem by detecting the specific exception thrown when a table already exists and ignoring it.