### PR TITLE
Lock version of json used in development/test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'json', '2.1.0'
+
 # Specify your gem's dependencies in dynamodb_framework.gemspec
 gemspec
 


### PR DESCRIPTION
This matches the version installed in the Dockerfile: https://github.com/Sage/dynamodb_framework/blob/master/Dockerfile#L7