### PR TITLE
SEC-2258 - Added new method update TTL attribute to table manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ This method is called to update the ttl attribute of a table.
 
 ### #get_ttl_status
 
-This method is called to get the ttl status of a table
+This method is called to get the ttl status of a table.
 
 **Params**
 

--- a/README.md
+++ b/README.md
@@ -568,18 +568,6 @@ This method is called to update the ttl attribute of a table.
 **Example**
         #Enable TTL
     update_ttl_attribute('ttl_example', true, 'ttl_timestamp')
-
-### #get_ttl_status
-
-This method is called to get the ttl status of a table.
-
-**Params**
-
-- **table_name** [String] [Required] This is the name of the table being checked.
-
-**Example**
-        #Check TTL
-    get_ttl_status('ttl_example')
     => {
             time_to_live_status: "ENABLED",
             attribute_name: "ttl_date"

--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ This method is called to update the ttl attribute of a table.
 **Params** 
 
  - **table_name** [String] [Required] This is the name of the table the attribute belongs to.
- - **time_to_live_status** [Boolean] [Required] This is true to turn TTL on on the table or false to turn it off.
+ - **enabled** [Boolean] [Required] This is true to turn TTL on the table or false to turn it off.
  - **attribute_name** [String] [Required] This is the name of the attribute that is going to be used for TTL.
 
 **Example**

--- a/README.md
+++ b/README.md
@@ -566,8 +566,24 @@ This method is called to update the ttl attribute of a table.
  - **attribute_name** [String] [Required] This is the name of the attribute that is going to be used for TTL.
 
 **Example**
-    #Enable TTL
+        #Enable TTL
     update_ttl_attribute('ttl_example', true, 'ttl_timestamp')
+
+### #get_ttl_status
+
+This method is called to get the ttl status of a table
+
+**Params**
+
+- **table_name** [String] [Required] This is the name of the table being checked.
+
+**Example**
+        #Check TTL
+    get_ttl_status('ttl_example')
+    => {
+            time_to_live_status: "ENABLED",
+            attribute_name: "ttl_date"
+        }
 
 ### #has_index?(table_name, index_name)
 

--- a/README.md
+++ b/README.md
@@ -568,6 +568,18 @@ This method is called to update the ttl attribute of a table.
 **Example**
         #Enable TTL
     update_ttl_attribute('ttl_example', true, 'ttl_timestamp')
+
+### #get_ttl_status
+
+This method is called to get the ttl status of a table.
+
+**Params**
+
+- **table_name** [String] [Required] This is the name of the table being checked.
+
+**Example**
+        #Check TTL
+    get_ttl_status('ttl_example')
     => {
             time_to_live_status: "ENABLED",
             attribute_name: "ttl_date"

--- a/README.md
+++ b/README.md
@@ -555,6 +555,20 @@ This method is called to update the throughput required by an index.
     #update the index
     manager.update_index_throughput('event_tracking', 'type_index', 50, 20)
 
+### #update_ttl_attribute
+
+This method is called to update the ttl attribute of a table.
+
+**Params** 
+
+ - **table_name** [String] [Required] This is the name of the table the attribute belongs to.
+ - **time_to_live_status** [Boolean] [Required] This is true to turn TTL on on the table or false to turn it off.
+ - **attribute_name** [String] [Required] This is the name of the attribute that is going to be used for TTL.
+
+**Example**
+    #Enable TTL
+    update_ttl_attribute('ttl_example', true, 'ttl_timestamp')
+
 ### #has_index?(table_name, index_name)
 
 This method is called to check if an index exists on a table within the database.

--- a/lib/dynamodb_framework/dynamodb_table_manager.rb
+++ b/lib/dynamodb_framework/dynamodb_table_manager.rb
@@ -277,7 +277,7 @@ module DynamoDbFramework
         sleep(5)
       end
 
-      raise "Timeout occurred while waiting for table: #{table_name}, to become active."
+      raise "Timeout occurred while waiting for table: #{table_name}, to update TTL status."
 
     end
 

--- a/lib/dynamodb_framework/dynamodb_table_manager.rb
+++ b/lib/dynamodb_framework/dynamodb_table_manager.rb
@@ -116,6 +116,25 @@ module DynamoDbFramework
       DynamoDbFramework.logger.info "[#{self.class}] -Table: [#{table_name}] updated."
     end
 
+    def update_ttl_attribute(table_name, time_to_live_status, attribute_name)
+      table = {
+          :table_name => table_name,
+          :time_to_live_specification => {
+            :enabled => time_to_live_status,
+            :attribute_name => attribute_name
+          }
+      }
+
+      DynamoDbFramework.logger.info "[#{self.class}] -Updating TTL Attribute: #{attribute_name}."
+      dynamodb.client.update_time_to_live(table)
+
+      # wait for table to be updated
+      DynamoDbFramework.logger.info "[#{self.class}] -Waiting for table: [#{table_name}] to be updated."
+      wait_until_active(table_name)
+
+      DynamoDbFramework.logger.info "[#{self.class}] -Table: [#{table_name}] updated."
+    end
+
     def drop_index(table_name, index_name)
       unless has_index?(table_name, index_name)
         return

--- a/lib/dynamodb_framework/dynamodb_table_manager.rb
+++ b/lib/dynamodb_framework/dynamodb_table_manager.rb
@@ -133,9 +133,7 @@ module DynamoDbFramework
       wait_until_active(table_name)
 
       DynamoDbFramework.logger.info "[#{self.class}] -Table: [#{table_name}] updated."
-    end
 
-    def get_ttl_status(table_name)
       table = {
         :table_name => table_name
       }

--- a/lib/dynamodb_framework/dynamodb_table_manager.rb
+++ b/lib/dynamodb_framework/dynamodb_table_manager.rb
@@ -116,11 +116,11 @@ module DynamoDbFramework
       DynamoDbFramework.logger.info "[#{self.class}] -Table: [#{table_name}] updated."
     end
 
-    def update_ttl_attribute(table_name, time_to_live_status, attribute_name)
+    def update_ttl_attribute(table_name, enabled, attribute_name)
       table = {
           :table_name => table_name,
           :time_to_live_specification => {
-            :enabled => time_to_live_status,
+            :enabled => enabled,
             :attribute_name => attribute_name
           }
       }
@@ -133,6 +133,14 @@ module DynamoDbFramework
       wait_until_active(table_name)
 
       DynamoDbFramework.logger.info "[#{self.class}] -Table: [#{table_name}] updated."
+    end
+
+    def get_ttl_status(table_name)
+      table = {
+        :table_name => table_name
+      }
+
+      dynamodb.client.describe_time_to_live(table)['time_to_live_description']
     end
 
     def drop_index(table_name, index_name)

--- a/lib/dynamodb_framework/dynamodb_table_manager.rb
+++ b/lib/dynamodb_framework/dynamodb_table_manager.rb
@@ -130,10 +130,12 @@ module DynamoDbFramework
 
       # wait for table to be updated
       DynamoDbFramework.logger.info "[#{self.class}] -Waiting for table: [#{table_name}] to be updated."
-      wait_until_active(table_name)
+      wait_until_ttl_changed(table_name)
 
       DynamoDbFramework.logger.info "[#{self.class}] -Table: [#{table_name}] updated."
+    end
 
+    def get_ttl_status(table_name)
       table = {
         :table_name => table_name
       }
@@ -258,6 +260,24 @@ module DynamoDbFramework
       end
 
       raise "Timeout occurred while waiting for table: #{table_name}, index: #{index_name}, to be dropped."
+
+    end
+
+    def wait_until_ttl_changed(table_name)
+
+      end_time = wait_timeout
+      while Time.now < end_time do
+
+        status = get_ttl_status(table_name)
+
+        if status == 'ENABLED' || 'DISABLED'
+          return
+        end
+
+        sleep(5)
+      end
+
+      raise "Timeout occurred while waiting for table: #{table_name}, to become active."
 
     end
 

--- a/lib/dynamodb_framework/dynamodb_table_manager.rb
+++ b/lib/dynamodb_framework/dynamodb_table_manager.rb
@@ -268,9 +268,9 @@ module DynamoDbFramework
       end_time = wait_timeout
       while Time.now < end_time do
 
-        status = get_ttl_status(table_name)
+        status = get_ttl_status(table_name)['time_to_live_status']
 
-        if status == 'ENABLED' || 'DISABLED'
+        if status == 'ENABLED' || status == 'DISABLED'
           return
         end
 

--- a/script/docker-compose.yml
+++ b/script/docker-compose.yml
@@ -1,19 +1,23 @@
 version: '2.1'
 
 services:
-  dynamodb:
-    image: codeguru/dynamodb:1.0.0
-    command: -port 8000
+  localstack:
+    image: localstack/localstack
+    environment:
+      - SERVICES=dynamodb:4569
+      - DEFAULT_REGION=eu-west-1
+      - HOSTNAME_EXTERNAL=localstack
+      - DEBUG=1
     ports:
-      - "8000:8000"
+      - "4569:4569"
 
   testrunner:
     image: sageone/dynamodb_test_runner
     container_name: test_runner
     command: sh -c "while true; do echo 'Container is running..'; sleep 5; done"
     environment:
-      - DYNAMODB_ENDPOINT=http://dynamodb:8000
+      - DYNAMODB_ENDPOINT=http://localstack:4569
     depends_on:
-      - dynamodb
+      - localstack
     volumes:
       - ../:/dynamodb_framework

--- a/spec/dynamodb_framework/dynamodb_table_manager_spec.rb
+++ b/spec/dynamodb_framework/dynamodb_table_manager_spec.rb
@@ -117,6 +117,29 @@ RSpec.describe DynamoDbFramework::TableManager do
 
   end
 
+  it 'can update the TTL attribute' do
+
+    exists = subject.exists?('update_ttl_test')
+
+    if exists
+      subject.drop('update_ttl_test')
+    end
+
+
+    builder = DynamoDbFramework::AttributesBuilder.new
+    builder.add(:id, :S)
+    builder.add(:name, :S)
+    builder.add(:number, :N)
+    builder.add(:ttl_date, :N)
+
+    subject.create('update_ttl_test', attributes_builder.attributes, :id)
+
+    subject.update_ttl_attribute('update_ttl_test', true, 'ttl_date')
+
+    subject.drop('update_ttl_test')
+
+  end
+
   it 'can drop an existing global secondary index' do
 
     exists = subject.exists?('drop_index_test')

--- a/spec/dynamodb_framework/dynamodb_table_manager_spec.rb
+++ b/spec/dynamodb_framework/dynamodb_table_manager_spec.rb
@@ -130,7 +130,9 @@ RSpec.describe DynamoDbFramework::TableManager do
 
     subject.create('update_ttl_test', builder.attributes, :ttl_date)
 
-    expect(subject.update_ttl_attribute('update_ttl_test', true, 'ttl_date')['time_to_live_status']).to eq('ENABLED')
+    subject.update_ttl_attribute('update_ttl_test', true, 'ttl_date')
+
+    expect(subject.get_ttl_status('update_ttl_test')['time_to_live_status']).to eq('ENABLED')
 
     subject.drop('update_ttl_test')
 

--- a/spec/dynamodb_framework/dynamodb_table_manager_spec.rb
+++ b/spec/dynamodb_framework/dynamodb_table_manager_spec.rb
@@ -125,16 +125,14 @@ RSpec.describe DynamoDbFramework::TableManager do
       subject.drop('update_ttl_test')
     end
 
-
     builder = DynamoDbFramework::AttributesBuilder.new
-    builder.add(:id, :S)
-    builder.add(:name, :S)
-    builder.add(:number, :N)
     builder.add(:ttl_date, :N)
 
-    subject.create('update_ttl_test', attributes_builder.attributes, :id)
+    subject.create('update_ttl_test', builder.attributes, :ttl_date)
 
     subject.update_ttl_attribute('update_ttl_test', true, 'ttl_date')
+
+    expect(subject.get_ttl_status('update_ttl_test')['time_to_live_status']).to eq('ENABLED')
 
     subject.drop('update_ttl_test')
 

--- a/spec/dynamodb_framework/dynamodb_table_manager_spec.rb
+++ b/spec/dynamodb_framework/dynamodb_table_manager_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe DynamoDbFramework::TableManager do
   it 'handles timeouts when dynamodb fails to respond' do
     allow(subject).to receive('wait_timeout').and_return(Time.now)
 
-    expect{subject.wait_until_ttl_changed('update_ttl_test')}.to raise_error("Timeout occurred while waiting for table: update_ttl_test, to become active.")
+    expect{subject.wait_until_ttl_changed('update_ttl_test')}.to raise_error("Timeout occurred while waiting for table: update_ttl_test, to update TTL status.")
   end
 
   it 'can drop an existing global secondary index' do

--- a/spec/dynamodb_framework/dynamodb_table_manager_spec.rb
+++ b/spec/dynamodb_framework/dynamodb_table_manager_spec.rb
@@ -130,9 +130,7 @@ RSpec.describe DynamoDbFramework::TableManager do
 
     subject.create('update_ttl_test', builder.attributes, :ttl_date)
 
-    subject.update_ttl_attribute('update_ttl_test', true, 'ttl_date')
-
-    expect(subject.get_ttl_status('update_ttl_test')['time_to_live_status']).to eq('ENABLED')
+    expect(subject.update_ttl_attribute('update_ttl_test', true, 'ttl_date')['time_to_live_status']).to eq('ENABLED')
 
     subject.drop('update_ttl_test')
 

--- a/spec/dynamodb_framework/dynamodb_table_manager_spec.rb
+++ b/spec/dynamodb_framework/dynamodb_table_manager_spec.rb
@@ -138,6 +138,35 @@ RSpec.describe DynamoDbFramework::TableManager do
 
   end
 
+  it 'can disable the TTL attribute' do
+
+    exists = subject.exists?('update_ttl_test')
+
+    if exists
+      subject.drop('update_ttl_test')
+    end
+
+    builder = DynamoDbFramework::AttributesBuilder.new
+    builder.add(:ttl_date, :N)
+
+    subject.create('update_ttl_test', builder.attributes, :ttl_date)
+
+    subject.update_ttl_attribute('update_ttl_test', true, 'ttl_date')
+
+    subject.update_ttl_attribute('update_ttl_test', false, 'ttl_date')
+
+    expect(subject.get_ttl_status('update_ttl_test')['time_to_live_status']).to eq('DISABLED')
+
+    subject.drop('update_ttl_test')
+
+  end
+
+  it 'handles timeouts when dynamodb fails to respond' do
+    allow(subject).to receive('wait_timeout').and_return(Time.now)
+
+    expect{subject.wait_until_ttl_changed('update_ttl_test')}.to raise_error("Timeout occurred while waiting for table: update_ttl_test, to become active.")
+  end
+
   it 'can drop an existing global secondary index' do
 
     exists = subject.exists?('drop_index_test')


### PR DESCRIPTION
This also swapped the tests to using Localstack over a local docker instance as local docker doesn't support the `update_ttl_attribute` method. 