### PR TITLE
Use wildcard for gem filename

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,6 @@ jobs:
           chmod 0600 $HOME/.gem/credentials
           printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
           gem build dynamodb_framework.gemspec
-          gem push dynamodb_framework.gem
+          gem push dynamodb_framework-*.gem
         env:
           GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"


### PR DESCRIPTION
Attempting to fix gem publishing GH Action which had failed with:

```
ERROR:  While executing gem ... (Gem::Package::FormatError)
    No such file or directory @ rb_sysopen - dynamodb_framework.gem
```